### PR TITLE
Added default namespace declaration for mapsource files

### DIFF
--- a/pkg/maps/4UMaps.xml
+++ b/pkg/maps/4UMaps.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map>
+<map xmlns="http://www.gpxsee.org/xsd/map.xsd">
 	<name>4UMaps</name>
 	<url>http://4umaps.eu/$z/$x/$y.png</url>
 	<zoom min="2" max="15"/>

--- a/pkg/maps/OpenStreetMap.xml
+++ b/pkg/maps/OpenStreetMap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map>
+<map xmlns="http://www.gpxsee.org/xsd/map.xsd">
 	<name>Open Street Map</name>
 	<url>http://tile.openstreetmap.org/$z/$x/$y.png</url>
 	<copyright>Map data: © OpenStreetMap contributors (ODbL) | Rendering: © OpenStreetMap (CC-BY-SA)</copyright>

--- a/pkg/maps/OpenTopoMap.xml
+++ b/pkg/maps/OpenTopoMap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map>
+<map xmlns="http://www.gpxsee.org/xsd/map.xsd">
 	<name>Open Topo Map</name>
 	<url>https://a.tile.opentopomap.org/$z/$x/$y.png</url>
 	<zoom max="17"/>

--- a/pkg/maps/USGS-imagery.xml
+++ b/pkg/maps/USGS-imagery.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map>
+<map xmlns="http://www.gpxsee.org/xsd/map.xsd">
 	<name>USGS Imagery</name>
 	<url>https://navigator.er.usgs.gov/tiles/aerial_Imagery.cgi/$z/$x/$y</url>
 	<zoom min="2" max="15"/>

--- a/pkg/maps/USGS-topo.xml
+++ b/pkg/maps/USGS-topo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map>
+<map xmlns="http://www.gpxsee.org/xsd/map.xsd">
 	<name>USGS Topo</name>
 	<url>https://navigator.er.usgs.gov/tiles/tcr.cgi/$z/$x/$y.png</url>
 	<zoom min="2" max="15"/>


### PR DESCRIPTION
Generally, it's a good practice to specify the default namespace for the XML document. Moreover, these mapsource files are used as examples for creating own maps, so xmlns is a good hint for users about mapfile format (not everyone reads [documentation](http://www.gpxsee.org/doc.html) at first).