### PR TITLE
Update fitparser.cpp

### DIFF
--- a/src/data/fitparser.cpp
+++ b/src/data/fitparser.cpp
@@ -270,8 +270,40 @@ bool FITParser::parseData(TrackData &track, MessageDefinition *def,
 			  + 631065600));
 			track.append(trackpoint);
 		} else {
-			if (trackpoint.coordinates().isNull())
-				warning("Missing coordinates");
+            if (trackpoint.coordinates().isNull())
+            {
+                if (track.size() > 0  &&
+                        (trackpoint.hasElevation() ||
+                         trackpoint.hasHeartRate() ||
+                         trackpoint.hasCadence() ||
+                         trackpoint.hasSpeed() ||
+                         trackpoint.hasPower() ||
+                         trackpoint.hasTemperature()))
+                {
+                    Trackpoint lastTp = track.last();
+                    trackpoint.setCoordinates(lastTp.coordinates());
+                    trackpoint.setTimestamp(lastTp.timestamp());
+                    if (lastTp.hasElevation())
+                        trackpoint.setElevation(lastTp.elevation());
+                    if (lastTp.hasHeartRate())
+                        trackpoint.setHeartRate(lastTp.heartRate());
+                    if (lastTp.hasCadence())
+                        trackpoint.setCadence(lastTp.cadence());
+                    if (lastTp.hasSpeed())
+                        trackpoint.setSpeed(lastTp.speed());
+                    if (lastTp.hasPower())
+                        trackpoint.setPower(lastTp.power());
+                    if (lastTp.hasTemperature())
+                        trackpoint.setTemperature(lastTp.temperature());
+
+                    track.removeLast();
+                    track.append(trackpoint);
+                    warning("Records merged with last set of coordinates");
+                }
+                else {
+                    warning("Missing coordinates");
+                }
+            }
 			else {
 				_errorString = "Invalid coordinates";
 				return false;

--- a/src/data/fitparser.cpp
+++ b/src/data/fitparser.cpp
@@ -283,17 +283,17 @@ bool FITParser::parseData(TrackData &track, MessageDefinition *def,
                     Trackpoint lastTp = track.last();
                     trackpoint.setCoordinates(lastTp.coordinates());
                     trackpoint.setTimestamp(lastTp.timestamp());
-                    if (lastTp.hasElevation())
+                    if (lastTp.hasElevation() && !trackpoint.hasElevation())
                         trackpoint.setElevation(lastTp.elevation());
-                    if (lastTp.hasHeartRate())
+                    if (lastTp.hasHeartRate() && !trackpoint.hasHeartRate())
                         trackpoint.setHeartRate(lastTp.heartRate());
-                    if (lastTp.hasCadence())
+                    if (lastTp.hasCadence() && !trackpoint.hasCadence())
                         trackpoint.setCadence(lastTp.cadence());
-                    if (lastTp.hasSpeed())
+                    if (lastTp.hasSpeed() && !trackpoint.hasSpeed())
                         trackpoint.setSpeed(lastTp.speed());
-                    if (lastTp.hasPower())
+                    if (lastTp.hasPower() && !trackpoint.hasPower())
                         trackpoint.setPower(lastTp.power());
-                    if (lastTp.hasTemperature())
+                    if (lastTp.hasTemperature() && !trackpoint.hasTemperature())
                         trackpoint.setTemperature(lastTp.temperature());
 
                     track.remove(track.size() - 1);

--- a/src/data/fitparser.cpp
+++ b/src/data/fitparser.cpp
@@ -296,7 +296,7 @@ bool FITParser::parseData(TrackData &track, MessageDefinition *def,
                     if (lastTp.hasTemperature())
                         trackpoint.setTemperature(lastTp.temperature());
 
-                    track.removeLast();
+                    track.remove(track.size() - 1);
                     track.append(trackpoint);
                     warning("Records merged with last set of coordinates");
                 }


### PR DESCRIPTION
Some cycling computer devices, such as the Bryton Rider 310, use multiple record types in one FIT file. E.g., the first record is the GPS data, the second one is sensor data such as the heart rate and cadence. The second data comes with no coordinates. The proposed change merges the data of multiple records into one trackpoint while parsing, thus enabling GPXSee to display these sensors' data as well.