### PR TITLE
Support cadence and speed in TrackPointExtension

### DIFF
--- a/src/data/gpxparser.cpp
+++ b/src/data/gpxparser.cpp
@@ -65,6 +65,10 @@ void GPXParser::tpExtension(Trackpoint &trackpoint)
 	while (_reader.readNextStartElement()) {
 		if (_reader.name() == QLatin1String("hr"))
 			trackpoint.setHeartRate(number());
+		else if (_reader.name() == QLatin1String("cad"))
+			trackpoint.setCadence(number());
+		else if (_reader.name() == QLatin1String("speed"))
+			trackpoint.setSpeed(number());
 		else if (_reader.name() == QLatin1String("atemp"))
 			trackpoint.setTemperature(number());
 		else


### PR DESCRIPTION
Hi

GPXSee fails to show my cadence graph and I find that it's because of the TrackPointExtension parser.
This PR will fix this

This is my `trkpt` data:
```xml
      <trkpt lat="xxxx" lon="yyyy">
        <ele>45.659828186035156</ele>
        <time>2018-12-17T19:24:37+08:00</time>
        <extensions>
          <gpxtpx:TrackPointExtension>
            <gpxtpx:hr>162</gpxtpx:hr>
            <gpxtpx:cad>93</gpxtpx:cad>
          </gpxtpx:TrackPointExtension>
        </extensions>
      </trkpt>
```

According to the [TrackPointExtension Schema](https://www8.garmin.com/xmlschemas/TrackPointExtensionv2.xsd)


- `hr` is for heart rate
- `cad` is for cadence
- `speed` for speed
