### PR TITLE
Fix speed when "Recorded by device" is checked

### DIFF
--- a/src/data/track.cpp
+++ b/src/data/track.cpp
@@ -217,7 +217,7 @@ Graph Track::speed() const
 				v = 0;
 				stop.append(gs.size());
 			} else if (_useReportedSpeed && sd.at(j).hasSpeed()
-			  && seg.outliers.contains(j))
+			  && !seg.outliers.contains(j))
 				v = sd.at(j).speed();
 			else if (!std::isnan(seg.speed.at(j)) && !seg.outliers.contains(j))
 				v = seg.speed.at(j);


### PR DESCRIPTION
The speed values from the device were taken into account for GPS outlier points only. This makes sense only if the speed calculated from the GPS locations is considered to be more reliable, which does not appear to be true.

The behavior is especially unexpected, when the "Eliminate GPS outliers" is unchecked. In this case the device's speed values are never seen.

Actually, I'm not convinced about the correct fix. Please, also consider the following alternatives:
- **(seg.outliers.contains(j) || !_outlierEliminate)** -- Existing behavior only with "outliers" turned-on
- just remove the "outliers" condition -- The user wants to see the data from device regardless on GPS coverage