### PR TITLE
Fix potential minor issue with gpiparser::speed

### DIFF
--- a/src/data/gpiparser.cpp
+++ b/src/data/gpiparser.cpp
@@ -140,7 +140,7 @@ static quint8 readRecordHeader(QDataStream &stream, RecordHeader &hdr)
 {
 	stream >> hdr.type >> hdr.flags >> hdr.size;
 	if (hdr.flags & 0xA)
-		stream >> hdr.extra;
+		stream >> hdr.extra;			
 	return (hdr.flags & 0xA) ? 12 : 8;
 }
 
@@ -428,9 +428,9 @@ static int speed(quint8 flags)
 {
 	switch (flags >> 4) {
 		case 0x8:
-			return 40;
-		case 0x9:
 			return 30;
+		case 0x9:
+			return 40;
 		case 0xA:
 			return 50;
 		case 0xB:


### PR DESCRIPTION
Hi. I run a similar project. I was looking for another other that had solved the problem I needed and while I struck out, I was looking at your code. I caught something that I'm not sure is wrong, ut sure looks like these are reversed. HTH.

When decoding contents of 8(30mps) and 9(40mps) it seems likely that one of these has a typo. Probably.

It's possible this is broken as I'm not building it or running anyhing beyond presubmit.. I'm not signing an CLA.