### PR TITLE
This commit adds a basic change-watcher of a loaded file with auto-up…

### DIFF
--- a/src/GUI/gui.cpp
+++ b/src/GUI/gui.cpp
@@ -197,6 +197,10 @@ QAction *GUI::createPOIFileAction(const QString &fileName)
 
 void GUI::createActions()
 {
+	// File watcher
+	_fileWatcher = new QFileSystemWatcher(this);
+	connect(_fileWatcher, SIGNAL(fileChanged(const QString &)), this, SLOT(fileChanged(const QString &)));
+
 	QActionGroup *ag;
 
 	// Action Groups
@@ -790,6 +794,7 @@ bool GUI::openFile(const QString &fileName, bool silent)
 		return false;
 
 	_files.append(fileName);
+	_fileWatcher->addPath(fileName);
 	_browser->setCurrent(fileName);
 	_fileActionGroup->setEnabled(true);
 	// Explicitly enable the reload action as it may be disabled by loadMapDir()
@@ -1344,6 +1349,7 @@ void GUI::closeFiles()
 		_tabs.at(i)->clear();
 	_mapView->clear();
 
+	_fileWatcher->removePaths(_files);
 	_files.clear();
 }
 
@@ -2157,6 +2163,12 @@ void GUI::writeSettings()
 	if (_options.hidpiMap != HIDPI_MAP_DEFAULT)
 		settings.setValue(HIDPI_MAP_SETTING, _options.hidpiMap);
 	settings.endGroup();
+}
+
+void GUI::fileChanged(const QString & path)
+{
+	_fileWatcher->addPath(path);
+	this->reloadFiles();
 }
 
 void GUI::readSettings()

--- a/src/GUI/gui.h
+++ b/src/GUI/gui.h
@@ -6,6 +6,7 @@
 #include <QList>
 #include <QDate>
 #include <QPrinter>
+#include <QFileSystemWatcher>
 #include "data/graph.h"
 #include "units.h"
 #include "timetype.h"
@@ -74,6 +75,7 @@ private slots:
 	void mapChanged();
 	void graphChanged(int);
 	void poiFileChecked(int);
+	void fileChanged(const QString & path);
 
 	void next();
 	void prev();
@@ -155,6 +157,7 @@ private:
 	QMenu *_poiFilesMenu;
 	QMenu *_mapMenu;
 
+	QFileSystemWatcher * _fileWatcher;
 	QActionGroup *_fileActionGroup;
 	QActionGroup *_navigationActionGroup;
 	QActionGroup *_mapsActionGroup;


### PR DESCRIPTION
Dear developer,

first of all I must thank you very much for GPXSee map viewer, which is free and is perfect!
Please, take this pull request as an inspiration for implementation of an auto-update system of loaded files.  I use this feature for displaying current coordinates from my GPS device. My external script downloads data from GPS device and writes them into a file, which is loaded in GPXSee program. With the introduced auto-update system the position from my GPS device is updated after each file change.
My pull request introduces this feature in its simplest form. The feature is implemented as default and cannot be switched off. It is so because I did not want to modify your GUI and wanted you to decide how to implement the switching on or off the feature. 
I hope that you will find the idea interesting and aligned with your future vision of GPXSee map viewer.


Best regards, Susnicek