### PR TITLE
Jpeg exif orientation

### DIFF
--- a/gpxsee.pro
+++ b/gpxsee.pro
@@ -21,6 +21,7 @@ HEADERS += src/common/config.h \
     src/GUI/axislabelitem.h \
     src/GUI/dirselectwidget.h \
     src/GUI/graphicsscene.h \
+    src/GUI/imagelabel.h \
     src/GUI/mapaction.h \
     src/GUI/mapitem.h \
     src/GUI/marginswidget.h \
@@ -230,6 +231,7 @@ HEADERS += src/common/config.h \
 SOURCES += src/main.cpp \
     src/GUI/axislabelitem.cpp \
     src/GUI/dirselectwidget.cpp \
+    src/GUI/imagelabel.cpp \
     src/GUI/mapitem.cpp \
     src/GUI/marginswidget.cpp \
     src/GUI/markerinfoitem.cpp \

--- a/src/GUI/graphicsscene.cpp
+++ b/src/GUI/graphicsscene.cpp
@@ -39,7 +39,7 @@ void GraphicsScene::helpEvent(QGraphicsSceneHelpEvent *event)
 	for (int i = 0; i < list.size(); i++) {
 		if (list.at(i)->type() == QGraphicsItem::UserType + 1) {
 			GraphicsItem *mi = static_cast<GraphicsItem*>(list.at(i));
-			Popup::show(event->screenPos(), mi->info(), event->widget());
+			Popup::show(event->screenPos(), mi->images(), mi->info(), event->widget());
 			return;
 		}
 	}

--- a/src/GUI/graphicsscene.h
+++ b/src/GUI/graphicsscene.h
@@ -3,6 +3,7 @@
 
 #include <QGraphicsScene>
 #include <QGraphicsItem>
+#include "data/imageinfo.h"
 
 class GraphicsItem : public QGraphicsItem
 {
@@ -10,6 +11,7 @@ public:
 	GraphicsItem(QGraphicsItem *parent = 0) : QGraphicsItem(parent) {}
 
 	virtual QString info() const = 0;
+	virtual const QVector<ImageInfo> images() const { return QVector<ImageInfo>(); }
 	int type() const {return QGraphicsItem::UserType + 1;}
 };
 

--- a/src/GUI/graphitem.cpp
+++ b/src/GUI/graphitem.cpp
@@ -345,6 +345,6 @@ void GraphItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 
 void GraphItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-	Popup::show(event->screenPos(), info(), event->widget());
+	Popup::show(event->screenPos(), images(), info(), event->widget());
 	GraphicsItem::mousePressEvent(event);
 }

--- a/src/GUI/imagelabel.cpp
+++ b/src/GUI/imagelabel.cpp
@@ -1,0 +1,22 @@
+#include <QDesktopServices>
+#include <QFileInfo>
+#include <QImageReader>
+#include <QLabel>
+#include <QMouseEvent>
+#include "imagelabel.h"
+
+ImageLabel::ImageLabel(QString path, QSize size, QWidget* parent, Qt::WindowFlags f)
+    : QLabel(parent, f), path(path) {
+	QImageReader reader(path);
+	reader.setAutoTransform(true);
+	reader.setScaledSize(size);
+	QImage image = reader.read();
+	QPixmap pixmap = QPixmap::fromImage(image);
+	setPixmap(pixmap);
+}
+
+ImageLabel::~ImageLabel() {}
+
+void ImageLabel::mousePressEvent(QMouseEvent* event) {
+	QDesktopServices::openUrl(QUrl::fromLocalFile(QFileInfo(path).absoluteFilePath()));
+}

--- a/src/GUI/imagelabel.cpp
+++ b/src/GUI/imagelabel.cpp
@@ -6,7 +6,7 @@
 #include "imagelabel.h"
 
 ImageLabel::ImageLabel(QString path, QSize size, QWidget* parent, Qt::WindowFlags f)
-    : QLabel(parent, f), path(path) {
+    : QLabel(parent, f), _path(path) {
 	QImageReader reader(path);
 	reader.setAutoTransform(true);
 	reader.setScaledSize(size);
@@ -18,5 +18,5 @@ ImageLabel::ImageLabel(QString path, QSize size, QWidget* parent, Qt::WindowFlag
 ImageLabel::~ImageLabel() {}
 
 void ImageLabel::mousePressEvent(QMouseEvent* event) {
-	QDesktopServices::openUrl(QUrl::fromLocalFile(QFileInfo(path).absoluteFilePath()));
+	QDesktopServices::openUrl(QUrl::fromLocalFile(QFileInfo(_path).absoluteFilePath()));
 }

--- a/src/GUI/imagelabel.h
+++ b/src/GUI/imagelabel.h
@@ -1,0 +1,17 @@
+#ifndef IMAGELABEL_H
+#define IMAGELABEL_H
+
+class ImageLabel : public QLabel {
+public:
+    ImageLabel(QString path, QSize size, QWidget* parent = 0, Qt::WindowFlags f = Qt::WindowFlags());
+    ~ImageLabel();
+
+protected:
+    void mousePressEvent(QMouseEvent* event);
+
+	QString path;
+
+};
+
+
+#endif // IMAGELABEL_H

--- a/src/GUI/imagelabel.h
+++ b/src/GUI/imagelabel.h
@@ -6,10 +6,12 @@ public:
     ImageLabel(QString path, QSize size, QWidget* parent = 0, Qt::WindowFlags f = Qt::WindowFlags());
     ~ImageLabel();
 
+    const QString &path() const {return _path;}
+
 protected:
     void mousePressEvent(QMouseEvent* event);
 
-	QString path;
+	QString _path;
 
 };
 

--- a/src/GUI/pathitem.cpp
+++ b/src/GUI/pathitem.cpp
@@ -445,6 +445,6 @@ void PathItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 
 void PathItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-	Popup::show(event->screenPos(), info(), event->widget());
+	Popup::show(event->screenPos(), images(), info(), event->widget());
 	GraphicsItem::mousePressEvent(event);
 }

--- a/src/GUI/pathtickitem.cpp
+++ b/src/GUI/pathtickitem.cpp
@@ -76,6 +76,6 @@ QRect PathTickItem::tickRect(int value)
 void PathTickItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
 	const PathItem *pi = static_cast<PathItem*>(parentItem());
-	Popup::show(event->screenPos(), pi->info(), event->widget());
+	Popup::show(event->screenPos(), pi->images(), pi->info(), event->widget());
 	QGraphicsItem::mousePressEvent(event);
 }

--- a/src/GUI/popup.cpp
+++ b/src/GUI/popup.cpp
@@ -189,12 +189,6 @@ void PopupWidget::deleteAfterTimer()
 		_timer.start(300, this);
 }
 
-void Popup::show(const QPoint &pos, const QString &text, QWidget *w)
-{
-	QVector<ImageInfo> images;
-	show(pos, images, text, w);
-}
-
 void Popup::show(const QPoint &pos, const QVector<ImageInfo> &images, const QString &text, QWidget *w)
 {
 	if (text.isEmpty())

--- a/src/GUI/popup.cpp
+++ b/src/GUI/popup.cpp
@@ -120,8 +120,8 @@ void PopupWidget::setImages(const QVector<ImageInfo> &images)
 		QSize size(thumbnailSize(img, qMin(960/images.size(), 240)));
 
 		QWidget *imageLabel = new ImageLabel(img.path(), size, this);
-		imageLabel->show();
 		imagesLayout->addWidget(imageLabel);
+		imageLabel->show();
 	}
 }
 

--- a/src/GUI/popup.cpp
+++ b/src/GUI/popup.cpp
@@ -7,14 +7,12 @@
 #include <QBasicTimer>
 #include <QScreen>
 #include <QApplication>
-#include <QImageReader>
 #include <QVBoxLayout>
-#include <QDesktopServices>
-#include <QFileInfo>
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
 #include <QDesktopWidget>
 #endif // QT 5.15
 #include "data/imageinfo.h"
+#include "imagelabel.h"
 #include "popup.h"
 
 static QSize thumbnailSize(const ImageInfo &img, int limit)
@@ -31,34 +29,6 @@ static QSize thumbnailSize(const ImageInfo &img, int limit)
 	}
 
 	return QSize(width, height);
-}
-
-class ImageLabel : public QLabel {
-public:
-    ImageLabel(QString path, QSize size, QWidget* parent = 0, Qt::WindowFlags f = Qt::WindowFlags());
-    ~ImageLabel();
-
-protected:
-    void mousePressEvent(QMouseEvent* event);
-
-	QString path;
-
-};
-
-ImageLabel::ImageLabel(QString path, QSize size, QWidget* parent, Qt::WindowFlags f)
-    : QLabel(parent, f), path(path) {
-	QImageReader reader(path);
-	reader.setAutoTransform(true);
-	reader.setScaledSize(size);
-	QImage image = reader.read();
-	QPixmap pixmap = QPixmap::fromImage(image);
-	setPixmap(pixmap);
-}
-
-ImageLabel::~ImageLabel() {}
-
-void ImageLabel::mousePressEvent(QMouseEvent* event) {
-	QDesktopServices::openUrl(QUrl::fromLocalFile(QFileInfo(path).absoluteFilePath()));
 }
 
 class PopupWidget : public QFrame

--- a/src/GUI/popup.cpp
+++ b/src/GUI/popup.cpp
@@ -58,7 +58,7 @@ PopupWidget *PopupWidget::_instance = 0;
 
 PopupWidget::PopupWidget(const QVector<ImageInfo> &images, const QString &text, QWidget *parent)
   : QFrame(parent, Qt::ToolTip | Qt::BypassGraphicsProxyWidget
-	| Qt::WindowDoesNotAcceptFocus)
+	| Qt::WindowDoesNotAcceptFocus | Qt::FramelessWindowHint)
 {
 	delete _instance;
 	_instance = this;

--- a/src/GUI/popup.cpp
+++ b/src/GUI/popup.cpp
@@ -84,12 +84,7 @@ PopupWidget::PopupWidget(const QVector<ImageInfo> &images, const QString &text, 
 	imagesLayout->setContentsMargins(0, 0, 0, 0);
 	imagesLayout->setSpacing(10);
 
-	for (int i = 0; i < images.size(); i++) {
-		const ImageInfo &img = images.at(i);
-		QSize size(thumbnailSize(img, qMin(960/images.size(), 240)));
-
-		imagesLayout->addWidget(new ImageLabel(img.path(), size));
-	}
+	setImages(images);
 
 	layout->addLayout(imagesLayout);
 

--- a/src/GUI/popup.cpp
+++ b/src/GUI/popup.cpp
@@ -74,6 +74,8 @@ PopupWidget::PopupWidget(const QVector<ImageInfo> &images, const QString &text, 
 	setMouseTracking(true);
 
 	QVBoxLayout *layout = new QVBoxLayout();
+	int margin = 1 + style()->pixelMetric(QStyle::PM_ToolTipLabelFrameWidth, 0, this);
+	layout->setContentsMargins(margin, margin, margin, margin);
 
 	for (int i = 0; i < images.size(); i++) {
 		const ImageInfo &img = images.at(i);
@@ -91,8 +93,7 @@ PopupWidget::PopupWidget(const QVector<ImageInfo> &images, const QString &text, 
 	}
 
 	label = new QLabel(text, this);
-	label->setMargin(1 + style()->pixelMetric(QStyle::PM_ToolTipLabelFrameWidth, 0,
-	  this));
+	label->setMargin(0);
 	label->setAlignment(Qt::AlignLeft);
 	label->setIndent(1);
 	label->setTextInteractionFlags(Qt::TextBrowserInteraction);

--- a/src/GUI/popup.cpp
+++ b/src/GUI/popup.cpp
@@ -44,6 +44,7 @@ public:
 
 	static PopupWidget *_instance;
 	QLabel *label;
+	QHBoxLayout *imagesLayout;
 
 protected:
 	void paintEvent(QPaintEvent *event);
@@ -77,12 +78,18 @@ PopupWidget::PopupWidget(const QVector<ImageInfo> &images, const QString &text, 
 	int margin = 1 + style()->pixelMetric(QStyle::PM_ToolTipLabelFrameWidth, 0, this);
 	layout->setContentsMargins(margin, margin, margin, margin);
 
+	imagesLayout = new QHBoxLayout();
+	imagesLayout->setContentsMargins(0, 0, 0, 0);
+	imagesLayout->setSpacing(10);
+
 	for (int i = 0; i < images.size(); i++) {
 		const ImageInfo &img = images.at(i);
 		QSize size(thumbnailSize(img, qMin(960/images.size(), 240)));
 
-		layout->addWidget(new ImageLabel(img.path(), size));
+		imagesLayout->addWidget(new ImageLabel(img.path(), size));
 	}
+
+	layout->addItem(imagesLayout);
 
 	label = new QLabel(text, this);
 	label->setMargin(0);

--- a/src/GUI/popup.cpp
+++ b/src/GUI/popup.cpp
@@ -121,7 +121,7 @@ void PopupWidget::setImages(const QVector<ImageInfo> &images)
 		if (imagesContain(images, imageLabel->path())) {
 			alreadyDisplayed.append(imageLabel->path());
 		} else {
-			imageLabel->deleteLater();
+			delete imageLabel;
 		}
 	}
 

--- a/src/GUI/popup.cpp
+++ b/src/GUI/popup.cpp
@@ -111,7 +111,7 @@ PopupWidget::~PopupWidget()
 
 void PopupWidget::setImages(const QVector<ImageInfo> &images)
 {
-	for (QLayoutItem *item = imagesLayout->takeAt(0); item != NULL; item = imagesLayout->takeAt(0)) {
+	for (QLayoutItem *item = imagesLayout->takeAt(0); item != 0; item = imagesLayout->takeAt(0)) {
 		item->widget()->deleteLater();
 	}
 

--- a/src/GUI/popup.h
+++ b/src/GUI/popup.h
@@ -11,7 +11,6 @@ class ImageInfo;
 class Popup
 {
 public:
-	static void show(const QPoint &pos, const QString &text, QWidget *w);
 	static void show(const QPoint &pos, const QVector<ImageInfo> &images, const QString &text, QWidget *w);
 	static void clear();
 };

--- a/src/GUI/popup.h
+++ b/src/GUI/popup.h
@@ -1,14 +1,18 @@
 #ifndef POPUP_H
 #define POPUP_H
 
+#include <QVector>
+
 class QPoint;
 class QString;
 class QWidget;
+class ImageInfo;
 
 class Popup
 {
 public:
 	static void show(const QPoint &pos, const QString &text, QWidget *w);
+	static void show(const QPoint &pos, const QVector<ImageInfo> &images, const QString &text, QWidget *w);
 	static void clear();
 };
 

--- a/src/GUI/tooltip.cpp
+++ b/src/GUI/tooltip.cpp
@@ -1,22 +1,6 @@
 #include "popup.h"
 #include "tooltip.h"
 
-static QSize thumbnailSize(const ImageInfo &img, int limit)
-{
-	int width, height;
-	if (img.size().width() > img.size().height()) {
-		width = qMin(img.size().width(), limit);
-		qreal ratio = img.size().width() / (qreal)img.size().height();
-		height = (int)(width / ratio);
-	} else {
-		height = qMin(img.size().height(), limit);
-		qreal ratio = img.size().height() / (qreal)img.size().width();
-		width = (int)(height / ratio);
-	}
-
-	return QSize(width, height);
-}
-
 void ToolTip::insert(const QString &key, const QString &value)
 {
 	_list.append(KV<QString, QString>(key, value));
@@ -25,20 +9,6 @@ void ToolTip::insert(const QString &key, const QString &value)
 QString ToolTip::toString() const
 {
 	QString html;
-
-	if (_images.size()) {
-		html = "<div align=\"center\">";
-		for (int i = 0; i < _images.size(); i++) {
-			const ImageInfo &img = _images.at(i);
-			QSize size(thumbnailSize(img, qMin(960/_images.size(), 240)));
-
-			html += QString("<a href=\"file:%0\">"
-			  "<img src=\"%0\" width=\"%1\" height=\"%2\"/></a>")
-			  .arg(img.path(), QString::number(size.width()),
-			  QString::number(size.height()));
-		}
-		html += "</div>";
-	}
 
 	if (!_list.isEmpty()) {
 		html += "<table>";

--- a/src/GUI/tooltip.h
+++ b/src/GUI/tooltip.h
@@ -3,20 +3,16 @@
 
 #include <QString>
 #include <QList>
-#include <QVector>
 #include "common/kv.h"
-#include "data/imageinfo.h"
 
 class ToolTip
 {
 public:
 	void insert(const QString &key, const QString &value);
-	void setImages(const QVector<ImageInfo> &images) {_images = images;}
 	QString toString() const;
 
 private:
 	QList<KV<QString, QString> > _list;
-	QVector<ImageInfo> _images;
 };
 
 #endif // TOOLTIP_H

--- a/src/GUI/waypointitem.cpp
+++ b/src/GUI/waypointitem.cpp
@@ -68,6 +68,11 @@ QString WaypointItem::info() const
 	return tt.toString();
 }
 
+const QVector<ImageInfo> WaypointItem::images() const
+{
+	return _waypoint.images();
+}
+
 WaypointItem::WaypointItem(const Waypoint &waypoint, Map *map,
   QGraphicsItem *parent) : GraphicsItem(parent)
 {
@@ -181,7 +186,7 @@ void WaypointItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 
 void WaypointItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-	Popup::show(event->screenPos(), _waypoint.images(), info(), event->widget());
+	Popup::show(event->screenPos(), images(), info(), event->widget());
 	/* Do not propagate the event any further as lower stacked items (path
 	   items) would replace the popup with their own popup */
 }

--- a/src/GUI/waypointitem.cpp
+++ b/src/GUI/waypointitem.cpp
@@ -64,7 +64,6 @@ QString WaypointItem::info() const
 		}
 		tt.insert(qApp->translate("WaypointItem", "Links"), links);
 	}
-	tt.setImages(_waypoint.images());
 
 	return tt.toString();
 }
@@ -182,7 +181,7 @@ void WaypointItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 
 void WaypointItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-	Popup::show(event->screenPos(), info(), event->widget());
+	Popup::show(event->screenPos(), _waypoint.images(), info(), event->widget());
 	/* Do not propagate the event any further as lower stacked items (path
 	   items) would replace the popup with their own popup */
 }

--- a/src/GUI/waypointitem.h
+++ b/src/GUI/waypointitem.h
@@ -31,6 +31,7 @@ public:
 	  QWidget *widget);
 
 	QString info() const;
+	const QVector<ImageInfo> images() const;
 
 	static void setUnits(Units units) {_units = units;}
 	static void setCoordinatesFormat(CoordinatesFormat format)


### PR DESCRIPTION
For https://github.com/tumic0/GPXSee/issues/385

Jpegs are rotated according to their exif information.

Done via https://doc.qt.io/qt-5/qimagereader.html#autoTransform

- Popup::show() now takes an additional parameter `images`
- I've added some code to not reload the images which are already displayed, because the mouse-hovering can cause a lot of calls to Popup::show()
- Only tested with Linux build
- Only tested with a single JPEG image per WaypointItem
- I am not so firm with Qt, so I'm not sure if it's the best idea to load the image
  in the constructor of a widget element..I'd rather have done it async/deferred.
- Feel free to change at will

I've read the contributing.md says you don't accept code changes.
I still decided to open this in case you change your mind.

Please let me know what you think. I'm open to all feedback. :)

Before:

![before](https://user-images.githubusercontent.com/1736847/127771608-daf78ad6-e1a5-4723-b574-dcd31e855aae.jpg)

After:

![after](https://user-images.githubusercontent.com/1736847/127771606-43f20c41-45a8-4e95-840b-33cdb1ff9f81.jpg)
