### PR TITLE
[RFC] Overlays. Fixes #178

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,24 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "defines": ["APP_VERSION"],
+            "compilerPath": "/usr/bin/g++",
+            "compileCommands": "./compile_commands.json",
+            "cStandard": "c11",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "gcc-x64",
+        "includePath": [
+            "${workspaceFolder}/src/**",
+            "/usr/include/x86_64-linux-gnu/qt6/**",
+            "/usr/local/include",
+            "/usr/include"
+        ],
+            "browse": {
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": "${default}"
+            }
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Make",
+            "type": "shell",
+            "command": "make -j10",
+            "args": [],
+            "options": {
+                "cwd": "${workspaceFolder}/"
+            },
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -75,3 +75,74 @@ different, GPL compatible, licenses:
   Source Code Disclaimer
 * [Projection parameters CSV files](pkg/csv) - BSD/EPSG/Public domain
 * [Mapsforge render theme](data/default.xml) and its [icons](icons/map/mapsforge) - LGPLv3
+
+## Ubuntu dev envionment
+
+sudo apt install -y build-essential qttools5-dev-tools qtbase5-private-dev qtpositioning5-dev
+sudo apt install qt6-base-dev qt6-base-private-dev qt6-serialbus-dev qt6-svg-dev qt6-positioning-dev
+
+
+## Code Architecture
+
+The UI lives in gui.cpp
+It for example:
+* handles screenChanged() events incl. dpi changes
+* loadInitialMaps() and loadInitialPOIs()
+* changes a map on menu click with mapAction() with Map.trigger() calling mapChanged calling setMap
+can use mapAction("alps/esloAlpsW") to force one
+to retrieve the map from the action
+Map *map = mapaction->data().value<Map*>();
+
+on mapLoadedDir,
+_mapView->loadMaps(actions) is called initially to read the map files and populate the actions
+
+The gui is a QWidget and includes a MapView defined in mapview.cpp (pointing back to its parent)
+
+It inherits from QGraphicsView.
+
+QGraphicsView visualizes the contents of a QGraphicsScene in a scrollable viewport.
+I can use CPU raster rendering or GPU if backed by a QGLWidget.
+
+analogy to the recording of a movie, the QGraphicsView would be the camera, the QGraphicsScene represents what is recorded, ie the scene. The scene is delimited by the sceneRect, if the camera is very close to the scene, its limits will not be observed, but if the camera is far away, the scenerect projection in the camera will not occupy the whole screen, so it will have to be aligned in some position, in the case of QGraphicsView the alignment property is used
+
+still unclear to me how these concepts work - eg:
+* setMap() and centerOn() calling mapToScene(viewport()->rect()).boundingRect());
+  _map->setOutputProjection(_outputProjection); # PCS::pcs(3857);  # from pcs.h
+	_map->setInputProjection(_inputProjection); #  GCS::gcs(4326);
+  connect(_map, &Map::tilesLoaded, this, &MapView::reloadMap);
+  _map->zoomFit(viewport()->rect().size(), cr);
+	_scene->setSceneRect(_map->bounds());
+* rescale() calling _sceene->setSceneRect(_map->bounds())
+* paintEvent() calling mapToScene(some weird math)
+
+why the only call to Map::draw is in MapView::drawBackground ? built-in QGraphicsView override pattern :)
+because QGraphicsView::drawBackground is called whenever something of the graphics view needs to be redrawn. This something might be smaller than the whole view for a better performance
+
+the interaction with Maps is indirect eg reloadMap calls _scene.invalidate()
+
+now, maps (inherits QObject) eg MBTilesMap
+
+draw(QPainter, QRect, Flags)
+calls drawTile(QPainter, QPixmap, QPointF)
+... which scales the pixmap with pixmap.setDevicePixelRatio(imageRatio()); and calls painter->drawPixmap
+
+GPXSee already knows how to do transparency, see the Map settings UI, and MapView::drawBackground which simply uses painter->setOpacity !
+now I just need to use QPainter.setCompositionMod(QPainter::CompositionMode_Multiply=13)
+Warning: Only a QPainter operating on a QImage fully supports all composition modes
+
+unfortunately we use QPixmap (
+  * The QPixmap class is an off-screen image representation that can be used as a paint device.
+  * The QImage class provides a hardware-independent image representation that allows direct access to the pixel data, and can be used as a paint device.
+short summary that usually (not always) applies:
+* If you plan to manipulate an image, modify it, change pixels on it, etc., use a QImage.
+* If you plan to draw the same image more than once on the screen, convert it to a QPixmap.
+
+
+
+so the plan is (ssumign I can ignore the Warning above!!!)
+
+have an array of _mask in addition to _map
+draw all of them in drawBackground
+profit!
+
+)

--- a/gpxsee.pro
+++ b/gpxsee.pro
@@ -5,6 +5,8 @@ unix:!macx:!android {
 }
 VERSION = 13.0
 
+CONFIG += debug
+
 QT += core \
     gui \
     gui-private \

--- a/src/GUI/gui.cpp
+++ b/src/GUI/gui.cpp
@@ -1680,6 +1680,12 @@ static MapAction *findMapAction(const QList<QAction*> &mapActions,
 	return 0;
 }
 
+/// @brief
+/// @param node containing parsed maps
+/// @param action outputs last valid map
+/// @param silent whether to notify of failures
+/// @param existingActions already available maps, to avoid dupes
+/// @return if at least one valid map was found
 bool GUI::loadMapNode(const TreeNode<Map*> &node, MapAction *&action,
   bool silent, const QList<QAction*> &existingActions)
 {

--- a/src/GUI/gui.cpp
+++ b/src/GUI/gui.cpp
@@ -1943,6 +1943,12 @@ void GUI::mapChanged(QAction *action)
 	_mapView->setMap(_map);
 }
 
+void GUI::overlayChanged(QAction *action)
+{
+	_overlay = action->data().value<Map*>();
+	_mapView->setOverlay(action->isChecked()? _overlay : nullptr);
+}
+
 void GUI::nextMap()
 {
 	QAction *checked = _mapsActionGroup->checkedAction();

--- a/src/GUI/gui.cpp
+++ b/src/GUI/gui.cpp
@@ -63,6 +63,7 @@
 GUI::GUI()
 {
 	QString activeMap;
+	QString activeOverlay;
 	QStringList disabledPOIs;
 
 	_poi = new POI(this);
@@ -107,9 +108,9 @@ GUI::GUI()
 	_movingTime = 0;
 	_lastTab = 0;
 
-	readSettings(activeMap, disabledPOIs);
+	readSettings(activeMap, activeOverlay, disabledPOIs);
 
-	loadInitialMaps(activeMap);
+	loadInitialMaps(activeMap, activeOverlay);
 	loadInitialPOIs(disabledPOIs);
 
 	updateGraphTabs();
@@ -2293,6 +2294,7 @@ void GUI::writeSettings()
 	/* Map */
 	settings.beginGroup(SETTINGS_MAP);
 	WRITE(activeMap, _map->name());
+	WRITE(activeOverlay, _overlay ? _overlay->name() : "");
 	WRITE(showMap, _showMapAction->isChecked());
 	WRITE(cursorCoordinates, _showCoordinatesAction->isChecked());
 	settings.endGroup();
@@ -2448,7 +2450,7 @@ void GUI::writeSettings()
 	settings.endGroup();
 }
 
-void GUI::readSettings(QString &activeMap, QStringList &disabledPOIs)
+void GUI::readSettings(QString &activeMap, QString &activeOverlay, QStringList &disabledPOIs)
 {
 #define READ(name) \
 	(Settings::name.read(settings))
@@ -2508,6 +2510,7 @@ void GUI::readSettings(QString &activeMap, QStringList &disabledPOIs)
 		_mapView->showCursorCoordinates(true);
 	}
 	activeMap = READ(activeMap).toString();
+	activeOverlay = READ(activeOverlay).toString();
 	settings.endGroup();
 
 	/* Graph */
@@ -2667,6 +2670,8 @@ void GUI::readSettings(QString &activeMap, QStringList &disabledPOIs)
 	_options.palette = Palette(READ(paletteColor).value<QColor>(),
 	  READ(paletteShift).toDouble());
 	_options.mapOpacity = READ(mapOpacity).toInt();
+	_options.overlayOpacity = READ(overlayOpacity).toInt();
+	_options.overlayMode = static_cast<QPainter::CompositionMode>(READ(overlayMode).toInt());
 	_options.backgroundColor = READ(backgroundColor).value<QColor>();
 	_options.crosshairColor = READ(crosshairColor).value<QColor>();
 	_options.infoColor = READ(infoColor).value<QColor>();
@@ -2739,6 +2744,8 @@ void GUI::loadOptions()
 
 	_mapView->setPalette(_options.palette);
 	_mapView->setMapOpacity(_options.mapOpacity);
+	_mapView->setOverlayOpacity(_options.overlayOpacity);
+	_mapView->setOverlayMode(_options.overlayMode);
 	_mapView->setBackgroundColor(_options.backgroundColor);
 	_mapView->setCrosshairColor(_options.crosshairColor);
 	_mapView->setInfoColor(_options.infoColor);
@@ -2842,6 +2849,8 @@ void GUI::updateOptions(const Options &options)
 
 	SET_VIEW_OPTION(palette, setPalette);
 	SET_VIEW_OPTION(mapOpacity, setMapOpacity);
+	SET_VIEW_OPTION(overlayOpacity, setOverlayOpacity);
+	SET_VIEW_OPTION(overlayMode, setOverlayMode);
 	SET_VIEW_OPTION(backgroundColor, setBackgroundColor);
 	SET_VIEW_OPTION(trackWidth, setTrackWidth);
 	SET_VIEW_OPTION(routeWidth, setRouteWidth);

--- a/src/GUI/gui.h
+++ b/src/GUI/gui.h
@@ -177,9 +177,9 @@ private:
 	QAction *mapAction(const QString &name);
 	QAction *overlayAction(const QString &name);
 	QGeoPositionInfoSource *positionSource(const Options &options);
-	void readSettings(QString &activeMap, QStringList &disabledPOIs);
+	void readSettings(QString &activeMap, QString &overlayMap, QStringList &disabledPOIs);
 
-	void loadInitialMaps(const QString &selected);
+	void loadInitialMaps(const QString &selected, const QString &selectedOvr);
 	void loadInitialPOIs(const QStringList &disabled);
 
 	void loadOptions();
@@ -295,6 +295,7 @@ private:
 
 	POI *_poi;
 	Map *_map;
+	Map *_overlay;
 	QGeoPositionInfoSource *_positionSource;
 	DEMLoader *_dem;
 

--- a/src/GUI/gui.h
+++ b/src/GUI/gui.h
@@ -91,6 +91,7 @@ private slots:
 	void showDEMTiles();
 
 	void mapChanged(QAction *action);
+	void overlayChanged(QAction *action);
 	void graphChanged(int);
 	void poiFileChecked(QAction *action);
 	void selectAllPOIs();
@@ -133,7 +134,8 @@ private:
 	qreal graphPlotHeight(const QRectF &rect, qreal ratio);
 
 	TreeNode<POIAction*> createPOIActionsNode(const TreeNode<QString> &node);
-	TreeNode<MapAction*> createMapActionsNode(const TreeNode<Map*> &node);
+	TreeNode<MapAction*> createMapActionsNode(const TreeNode<Map*> &node, QActionGroup* actionGroup);
+
 	void createMapNodeMenu(const TreeNode<MapAction*> &node, QMenu *menu,
 	  QAction *action = 0);
 	void createPOINodeMenu(const TreeNode<POIAction*> &node, QMenu *menu,
@@ -156,7 +158,7 @@ private:
 	bool loadMapNode(const TreeNode<Map*> &node, MapAction *&action,
 	  bool silent, const QList<QAction*> &existingActions);
 	void loadMapDirNode(const TreeNode<Map*> &node, QList<MapAction*> &actions,
-	  QMenu *menu, const QList<QAction*> &existingActions);
+	  QMenu *menu, QMenu *ovrmenu, const QList<QAction*> &existingActions);
 	void updateStatusBarInfo();
 	void updateWindowTitle();
 	bool updateGraphTabs();
@@ -173,6 +175,7 @@ private:
 	qreal time() const;
 	qreal movingTime() const;
 	QAction *mapAction(const QString &name);
+	QAction *overlayAction(const QString &name);
 	QGeoPositionInfoSource *positionSource(const Options &options);
 	void readSettings(QString &activeMap, QStringList &disabledPOIs);
 
@@ -198,10 +201,12 @@ private:
 #endif // Q_OS_ANDROID
 	QMenu *_poiMenu;
 	QMenu *_mapMenu;
+	QMenu *_overlayMenu;
 
 	QActionGroup *_fileActionGroup;
 	QActionGroup *_navigationActionGroup;
 	QActionGroup *_mapsActionGroup;
+	QActionGroup *_overlaysActionGroup;
 	QActionGroup *_poisActionGroup;
 #if !defined(Q_OS_MAC) && !defined(Q_OS_ANDROID)
 	QAction *_exitAction;
@@ -275,6 +280,7 @@ private:
 	QAction *_downloadDEMAction;
 	QAction *_showDEMTilesAction;
 	QAction *_mapsEnd;
+	QAction *_overlaysEnd;
 	QAction *_poisEnd;
 
 	QLabel *_fileNameLabel;

--- a/src/GUI/mapview.h
+++ b/src/GUI/mapview.h
@@ -61,6 +61,7 @@ public:
 
 	void setPalette(const Palette &palette);
 	void setPOI(POI *poi);
+	void setOverlay(Map *map);
 	void setMap(Map *map);
 	void setPositionSource(QGeoPositionInfoSource *source);
 	void setGraph(int index);
@@ -87,6 +88,8 @@ public:
 	void setPOISize(int size);
 	void setPOIColor(const QColor &color);
 	void setMapOpacity(int opacity);
+	void setOverlayOpacity(int opacity);
+	void setOverlayMode(QPainter::CompositionMode mode);
 	void setBackgroundColor(const QColor &color);
 	void useOpenGL(bool use);
 	void useAntiAliasing(bool use);
@@ -185,11 +188,14 @@ private:
 	qreal _res;
 
 	Map *_map;
+	Map* _overlay;
 	POI *_poi;
 	QGeoPositionInfoSource *_positionSource;
 
 	Palette _palette;
 	qreal _mapOpacity;
+	qreal _overlayOpacity;
+	QPainter::CompositionMode _overlayMode;
 	Projection _outputProjection, _inputProjection;
 
 	bool _showMap, _showTracks, _showRoutes, _showAreas, _showWaypoints,

--- a/src/GUI/optionsdialog.cpp
+++ b/src/GUI/optionsdialog.cpp
@@ -279,6 +279,12 @@ QWidget *OptionsDialog::createAppearancePage()
 	// Map
 	_mapOpacity = new PercentSlider();
 	_mapOpacity->setValue(_options.mapOpacity);
+	_overlayOpacity = new PercentSlider();
+	_overlayOpacity->setValue(_options.overlayOpacity);
+	_overlayMode = new QSpinBox();
+	_overlayMode->setMinimum(0);
+	_overlayMode->setMaximum(23); // CompositionMode_Exclusion
+	_overlayMode->setValue(_options.overlayMode);
 	_backgroundColor = new ColorBox();
 	_backgroundColor->setColor(_options.backgroundColor);
 	_backgroundColor->enableAlphaChannel(false);
@@ -292,6 +298,8 @@ QWidget *OptionsDialog::createAppearancePage()
 	QFormLayout *mapLayout = new QFormLayout();
 	mapLayout->addRow(tr("Background color:"), _backgroundColor);
 	mapLayout->addRow(tr("Map opacity:"), _mapOpacity);
+	mapLayout->addRow(tr("Overlay opacity:"), _overlayOpacity);
+	mapLayout->addRow(tr("Overlay composition mode:"), _overlayMode);
 	mapLayout->addRow(tr("Crosshair color:"), _crosshairColor);
 	mapLayout->addRow(tr("Info color:"), _infoColor);
 	mapLayout->addWidget(_infoBackground);
@@ -870,6 +878,8 @@ void OptionsDialog::accept()
 	_options.palette.setColor(_baseColor->color());
 	_options.palette.setShift(_colorOffset->value() / 100.0);
 	_options.mapOpacity = _mapOpacity->value();
+	_options.overlayOpacity = _overlayOpacity->value();
+	_options.overlayMode = static_cast<QPainter::CompositionMode>(_overlayMode->value());
 	_options.backgroundColor = _backgroundColor->color();
 	_options.crosshairColor = _crosshairColor->color();
 	_options.infoColor = _infoColor->color();

--- a/src/GUI/optionsdialog.h
+++ b/src/GUI/optionsdialog.h
@@ -3,6 +3,7 @@
 
 #include <QtGlobal>
 #include <QDialog>
+#include <QPainter>
 #include "palette.h"
 #include "units.h"
 #include "timezoneinfo.h"
@@ -41,6 +42,8 @@ struct Options {
 	bool pathAntiAliasing;
 	bool graphAntiAliasing;
 	int mapOpacity;
+	int overlayOpacity;
+	QPainter::CompositionMode overlayMode;
 	QColor backgroundColor;
 	QColor crosshairColor;
 	QColor infoColor;
@@ -125,6 +128,8 @@ private:
 	ColorBox *_baseColor;
 	PercentSlider *_colorOffset;
 	PercentSlider *_mapOpacity;
+	PercentSlider *_overlayOpacity;
+	QSpinBox *_overlayMode;
 	ColorBox *_backgroundColor;
 	ColorBox *_crosshairColor;
 	ColorBox *_infoColor;

--- a/src/GUI/settings.cpp
+++ b/src/GUI/settings.cpp
@@ -3,6 +3,7 @@
 #include <QPageLayout>
 #include <QPageSize>
 #include <QGeoPositionInfoSource>
+#include <QPainter>
 #include "common/config.h"
 #include "common/util.h"
 #include "data/graph.h"
@@ -127,6 +128,7 @@ const Settings::Setting &Settings::positionPlugin()
 	return s;
 }
 
+// Each setting is mapped to its key string in eg ~/.config/gpxsee/gpxsee.conf
 /* Window */
 #ifndef Q_OS_ANDROID
 SETTING(windowGeometry,      "geometry",               QByteArray()           );
@@ -143,6 +145,7 @@ SETTING(showToolbars,        "toolbar",                true                   );
 
 /* Map */
 SETTING(activeMap,           "map",                    "Open Street Map"      );
+SETTING(activeOverlay,       "overlay",                ""                     ); // should eventually be a QList? and use map name
 SETTING(showMap,             "show",                   true                   );
 SETTING(cursorCoordinates,   "coordinates",            false                  );
 
@@ -204,6 +207,8 @@ SETTING(pngFileName,         "fileName",               CWD("export.png")      );
 SETTING(paletteColor,        "paletteColor",           QColor(Qt::blue)       );
 SETTING(paletteShift,        "paletteShift",           0.62                   );
 SETTING(mapOpacity,          "mapOpacity",             100                    );
+SETTING(overlayOpacity,      "overlayOpacity",         50                     );
+SETTING(overlayMode,         "overlayMode",            QPainter::CompositionMode::CompositionMode_Multiply);
 SETTING(backgroundColor,     "backgroundColor",        QColor(Qt::white)      );
 SETTING(crosshairColor,      "crosshairColor",         QColor(Qt::red)        );
 SETTING(infoColor,           "infoColor",              QColor(Qt::black)      );

--- a/src/GUI/settings.h
+++ b/src/GUI/settings.h
@@ -86,6 +86,7 @@ public:
 
 	/* Map */
 	static const Setting activeMap;
+	static const Setting activeOverlay;
 	static const Setting showMap;
 	static const Setting cursorCoordinates;
 
@@ -148,6 +149,8 @@ public:
 	static const Setting paletteColor;
 	static const Setting paletteShift;
 	static const Setting mapOpacity;
+	static const Setting overlayOpacity;
+	static const Setting overlayMode;
 	static const Setting backgroundColor;
 	static const Setting crosshairColor;
 	static const Setting infoColor;

--- a/src/map/mbtilesmap.cpp
+++ b/src/map/mbtilesmap.cpp
@@ -261,7 +261,8 @@ void MBTilesMap::draw(QPainter *painter, const QRectF &rect, Flags flags)
 	int zoom = _zooms.at(_zi);
 	qreal scale = OSM::zoom2scale(zoom, _tileSize);
 	QRectF b(bounds());
-
+	// qInfo("MBT %s with _zi=%d z=%d :: draw rect = (%f, %f, %f, %f ) -> scale %f, bounds (%f, %f, %f, %f )",
+	// 	qPrintable(name()), _zi, _zooms.at(_zi), rect.left(), rect.bottom(), rect.right(), rect.top(), scale, b.left(), b.bottom(), b.right(), b.top());
 
 	QPoint tile = OSM::mercator2tile(QPointF(rect.topLeft().x() * scale,
 	  -rect.topLeft().y() * scale) * coordinatesRatio(), zoom);

--- a/src/map/mbtilesmap.cpp
+++ b/src/map/mbtilesmap.cpp
@@ -194,7 +194,7 @@ int MBTilesMap::zoomFit(const QSize &size, const RectC &rect)
 		}
 	}
 
-	return _zi;
+	return _zooms.at(_zi);
 }
 
 qreal MBTilesMap::resolution(const QRectF &rect)
@@ -205,13 +205,13 @@ qreal MBTilesMap::resolution(const QRectF &rect)
 int MBTilesMap::zoomIn()
 {
 	_zi = qMin(_zi + 1, _zooms.size() - 1);
-	return _zi;
+	return _zooms.at(_zi);
 }
 
 int MBTilesMap::zoomOut()
 {
 	_zi = qMax(_zi - 1, 0);
-	return _zi;
+	return _zooms.at(_zi);
 }
 
 void MBTilesMap::setDevicePixelRatio(qreal deviceRatio, qreal mapRatio)

--- a/src/map/mbtilesmap.h
+++ b/src/map/mbtilesmap.h
@@ -16,8 +16,14 @@ public:
 	RectC llBounds() {return _bounds;}
 	qreal resolution(const QRectF &rect);
 
-	int zoom() const {return _zi;}
-	void setZoom(int zoom) {_zi = zoom;}
+	int zoom() const {return _zooms.at(_zi);}
+	void setZoom(int zoom) {
+		for (int i = 1; i < _zooms.size(); i++) {
+			if (_zooms.at(i) > zoom)
+				break;
+			_zi = i;
+		}
+	}
 	int zoomFit(const QSize &size, const RectC &rect);
 	int zoomIn();
 	int zoomOut();


### PR DESCRIPTION
This is a request for comments, not ready for contribution and maybe never ;-)

still, it works for me with mbtiles. I use it for slope overlays. commit "3." and "4." are the most interesting to look at.

Some things are very brittle, from most important to least:

* the are not true layers in the scene, the main _map is master of everything (zoom levels available, bounds, ...) and overlay is just hacked on top in drawBackground. Consequences:
    * to sync the zooms I had to change get/setZoom logic to return global TMS zooms. might not be possible to do so accross non-TMS map formats. and as there's no way to disable the overlay at unavailable zoom levels, behaviour is undefined in this case.
    * the overlay state is kept in sync manually which means I certainly missed some things
* the menu duplication logic is in 3 places (not my fault ;-)), and anyway might not be the best UX (especially to support multiple overlays eventually)
* CompositionMode enum should have a ComboBox in Settings, not an integer.

Still, it's a in a good place to start the conversation :-)