### PR TITLE
support euc.world log files

### DIFF
--- a/gpxsee.pro
+++ b/gpxsee.pro
@@ -258,7 +258,8 @@ HEADERS += src/common/config.h \
     src/data/gpiparser.h \
     src/data/address.h \
     src/data/smlparser.h \
-    src/data/geojsonparser.h
+    src/data/geojsonparser.h \
+    src/data/eucworldparser.h
 
 SOURCES += src/main.cpp \
     src/GUI/crosshairitem.cpp \
@@ -452,7 +453,8 @@ SOURCES += src/main.cpp \
     src/data/cupparser.cpp \
     src/data/gpiparser.cpp \
     src/data/smlparser.cpp \
-    src/data/geojsonparser.cpp
+    src/data/geojsonparser.cpp \
+    src/data/eucworldparser.cpp
 
 DEFINES += APP_VERSION=\\\"$$VERSION\\\" \
     QT_NO_DEPRECATED_WARNINGS

--- a/src/data/data.cpp
+++ b/src/data/data.cpp
@@ -20,6 +20,7 @@
 #include "itnparser.h"
 #include "onmoveparsers.h"
 #include "twonavparser.h"
+#include "eucworldparser.h"
 #include "data.h"
 
 
@@ -45,6 +46,7 @@ static ITNParser itn;
 static OMDParser omd;
 static GHPParser ghp;
 static TwoNavParser twonav;
+static EUCWORLDParser euc;
 
 static QMultiMap<QString, Parser*> parsers()
 {
@@ -77,6 +79,7 @@ static QMultiMap<QString, Parser*> parsers()
 	map.insert("trk", &twonav);
 	map.insert("rte", &twonav);
 	map.insert("wpt", &twonav);
+	map.insert("log", &euc);
 
 	return map;
 }
@@ -173,6 +176,7 @@ QString Data::formats()
 	  + qApp->translate("Data", "SML files") + " (*.sml);;"
 	  + qApp->translate("Data", "TCX files") + " (*.tcx);;"
 	  + qApp->translate("Data", "TwoNav files") + " (*.rte *.trk *.wpt);;"
+	  + qApp->translate("Data", "Euc.world files") + " (*.log);;"
 	  + qApp->translate("Data", "All files") + " (*)";
 }
 

--- a/src/data/eucworldparser.cpp
+++ b/src/data/eucworldparser.cpp
@@ -63,7 +63,12 @@ bool EUCWORLDParser::parse(QFile *file, QList<TrackData> &tracks,
 			wp.setElevation(el);
 		}
 
-		waypoints.append(wp);
+		if (lat != lastlat || lon != lastlon) {
+			waypoints.append(wp);
+		}
+
+		lastlat = lat;
+		lastlon = lon;
 	}
 
 	return true;

--- a/src/data/eucworldparser.cpp
+++ b/src/data/eucworldparser.cpp
@@ -63,12 +63,12 @@ bool EUCWORLDParser::parse(QFile *file, QList<TrackData> &tracks,
 			wp.setElevation(el);
 		}
 
-		if (lat != lastlat || lon != lastlon) {
+		if (lat != _lastLat || lon != _lastLon) {
 			waypoints.append(wp);
 		}
 
-		lastlat = lat;
-		lastlon = lon;
+		_lastLat = lat;
+		_lastLon = lon;
 	}
 
 	return true;

--- a/src/data/eucworldparser.cpp
+++ b/src/data/eucworldparser.cpp
@@ -1,6 +1,6 @@
 #include <QByteArrayList>
 #include "common/csv.h"
-#include "csvparser.h"
+#include "eucworldparser.h"
 
 bool EUCWORLDParser::parse(QFile *file, QList<TrackData> &tracks,
   QList<RouteData> &routes, QList<Area> &polygons,

--- a/src/data/eucworldparser.cpp
+++ b/src/data/eucworldparser.cpp
@@ -1,0 +1,70 @@
+#include <QByteArrayList>
+#include "common/csv.h"
+#include "csvparser.h"
+
+bool EUCWORLDParser::parse(QFile *file, QList<TrackData> &tracks,
+  QList<RouteData> &routes, QList<Area> &polygons,
+  QVector<Waypoint> &waypoints)
+{
+	Q_UNUSED(tracks);
+	Q_UNUSED(routes);
+	Q_UNUSED(polygons);
+	CSV csv(file);
+	QByteArrayList entry;
+	bool ok;
+
+	// euc.world log files start with the field names (no less than 40)
+	//
+	if (!csv.readEntry(entry) || entry.size() < 40 || entry.at(0) != "datetime") {
+		_errorString = "Parse error (header not found)";
+		_errorLine = csv.line();
+		return false;
+	}
+
+	while (!csv.atEnd()) {
+		if (!csv.readEntry(entry) || entry.size() < 40) {
+			_errorString = "Parse error";
+			_errorLine = csv.line();
+			return false;
+		}
+
+		// fundamental fields:
+		//	0:  device timestamp, always present
+		//	5:  reported wheel speed (kph), always present
+		// 	25: gps_datetime
+		// 	29: gps_lat
+		// 	30: gps_lon
+		// 	31: gps_speed
+		// 	35: gps_alt
+		//
+		double lon = entry.at(30).toDouble(&ok);
+		if (!ok) {
+			continue;
+		}
+		if (lon < -180.0 || lon > 180.0) {
+			_errorString = "Invalid longitude";
+			_errorLine = csv.line();
+			return false;
+		}
+
+		double lat = entry.at(29).toDouble(&ok);
+		if (!ok) {
+			continue;
+		}
+		if (lat < -90.0 || lat > 90.0) {
+			_errorString = "Invalid latitude";
+			_errorLine = csv.line();
+			return false;
+		}
+		Waypoint wp(Coordinates(lon, lat));
+
+		double el = entry.at(35).toDouble(&ok);
+		if (ok) {
+			wp.setElevation(el);
+		}
+
+		waypoints.append(wp);
+	}
+
+	return true;
+}

--- a/src/data/eucworldparser.h
+++ b/src/data/eucworldparser.h
@@ -6,7 +6,7 @@
 class EUCWORLDParser : public Parser
 {
 public:
-	EUCWORLDParser() : _errorLine(0) {}
+	EUCWORLDParser() : _errorLine(0), lastlat(0.0), lastlon(0.0) {}
 
 	bool parse(QFile *file, QList<TrackData> &tracks, QList<RouteData> &routes,
 	  QList<Area> &polygons, QVector<Waypoint> &waypoints);
@@ -16,6 +16,9 @@ public:
 private:
 	QString _errorString;
 	int _errorLine;
+
+	double lastlat;
+	double lastlon;
 };
 
 #endif // EUCWORLDPARSER_H

--- a/src/data/eucworldparser.h
+++ b/src/data/eucworldparser.h
@@ -6,7 +6,7 @@
 class EUCWORLDParser : public Parser
 {
 public:
-	EUCWORLDParser() : _errorLine(0), lastlat(0.0), lastlon(0.0) {}
+	EUCWORLDParser() : _errorLine(0), _lastLat(0.0), _lastLon(0.0) {}
 
 	bool parse(QFile *file, QList<TrackData> &tracks, QList<RouteData> &routes,
 	  QList<Area> &polygons, QVector<Waypoint> &waypoints);
@@ -17,8 +17,8 @@ private:
 	QString _errorString;
 	int _errorLine;
 
-	double lastlat;
-	double lastlon;
+	double _lastLat;
+	double _lastLon;
 };
 
 #endif // EUCWORLDPARSER_H

--- a/src/data/eucworldparser.h
+++ b/src/data/eucworldparser.h
@@ -1,0 +1,21 @@
+#ifndef EUCWORLDPARSER_H
+#define EUCWORLDPARSER_H
+
+#include "parser.h"
+
+class EUCWORLDParser : public Parser
+{
+public:
+	EUCWORLDParser() : _errorLine(0) {}
+
+	bool parse(QFile *file, QList<TrackData> &tracks, QList<RouteData> &routes,
+	  QList<Area> &polygons, QVector<Waypoint> &waypoints);
+	QString errorString() const {return _errorString;}
+	int errorLine() const {return _errorLine;}
+
+private:
+	QString _errorString;
+	int _errorLine;
+};
+
+#endif // EUCWORLDPARSER_H


### PR DESCRIPTION
this adds preliminary support for [euc.world](https://euc.world) app log files.

euc.world saves electric unicycle riding data to "log" files consisting of a 40+ fields CSV including GPS data.
repeated latitude/longitude values get filtered out because of the unpredictable granularity of event records.

note - I'm not involved with euc.world project