### PR TITLE
Add middle mouse button drag in the GraphView

### DIFF
--- a/src/GUI/graphview.cpp
+++ b/src/GUI/graphview.cpp
@@ -346,11 +346,7 @@ void GraphView::mouseMoveEvent(QMouseEvent *e)
 {
 	if (e->buttons() & Qt::MiddleButton) {
 		QScrollBar *sb = horizontalScrollBar();
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
 		int x = e->x();
-#else // QT 5.15
-		int x = e->position().toPoint().x();
-#endif // QT 5.15
 		sb->setSliderPosition(sb->sliderPosition() - (x - _xStartDrag));
 		_xStartDrag = x;
 	}
@@ -360,17 +356,10 @@ void GraphView::mouseMoveEvent(QMouseEvent *e)
 
 void GraphView::mousePressEvent(QMouseEvent *e)
 {
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
 	if (e->button() == Qt::LeftButton)
 		newSliderPosition(mapToScene(e->pos()));
 	else if (e->button() == Qt::MiddleButton)
 		_xStartDrag = e->x();
-#else // QT 5.15
-	if (e->button() == Qt::LeftButton)
-		newSliderPosition(mapToScene(e->position().toPoint()));
-	else if (e->button() == Qt::MiddleButton)
-		_xStartDrag = e->position().toPoint().x();
-#endif // QT 5.15
 
 	QGraphicsView::mousePressEvent(e);
 }

--- a/src/GUI/graphview.cpp
+++ b/src/GUI/graphview.cpp
@@ -342,10 +342,35 @@ void GraphView::resizeEvent(QResizeEvent *e)
 	QGraphicsView::resizeEvent(e);
 }
 
+void GraphView::mouseMoveEvent(QMouseEvent *e)
+{
+	if (e->buttons() & Qt::MiddleButton) {
+		QScrollBar *sb = horizontalScrollBar();
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+		int x = e->x();
+#else // QT 5.15
+		int x = e->position().toPoint().x();
+#endif // QT 5.15
+		sb->setSliderPosition(sb->sliderPosition() - (x - _xStartDrag));
+		_xStartDrag = x;
+	}
+
+	QGraphicsView::mouseMoveEvent(e);
+}
+
 void GraphView::mousePressEvent(QMouseEvent *e)
 {
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
 	if (e->button() == Qt::LeftButton)
 		newSliderPosition(mapToScene(e->pos()));
+	else if (e->button() == Qt::MiddleButton)
+		_xStartDrag = e->x();
+#else // QT 5.15
+	if (e->button() == Qt::LeftButton)
+		newSliderPosition(mapToScene(e->position().toPoint()));
+	else if (e->button() == Qt::MiddleButton)
+		_xStartDrag = e->position().toPoint().x();
+#endif // QT 5.15
 
 	QGraphicsView::mousePressEvent(e);
 }

--- a/src/GUI/graphview.h
+++ b/src/GUI/graphview.h
@@ -57,6 +57,7 @@ protected:
 	void setUnits(Units units);
 
 	void resizeEvent(QResizeEvent *e);
+	void mouseMoveEvent(QMouseEvent *e);
 	void mousePressEvent(QMouseEvent *e);
 	void wheelEvent(QWheelEvent *e);
 	void changeEvent(QEvent *e);
@@ -122,6 +123,7 @@ private:
 	qreal _minYRange;
 
 	qreal _zoom;
+	int _xStartDrag;
 };
 
 #endif // GRAPHVIEW_H


### PR DESCRIPTION
It is very handy to "scroll" zoomed GraphView area using 
middle mouse button drag. Can't live without this feature.

Dragging occurs only horizontally.

#### Qt5/Qt6

In Qt6 `QMouseEvent::pos()` as well as `QMouseEvent::x()`
are marked as deprecated. For the GPXSee there was a commit
back in 2020 that added support for Qt6 including preprocessor
test for Qt version and choosing `QMouseEvent::pos()` vs 
`QMouseEvent::position()`. The latter is of QPointF type.

So, I added that preprocessor test and choice between the 
methods too. I hope I did the right thing)

