### PR TITLE
Fix Czech comment in gpxsee.desktop

### DIFF
--- a/pkg/linux/gpxsee.desktop
+++ b/pkg/linux/gpxsee.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=GPXSee
 Comment=GPS log file viewer and analyzer
-Comment[cz]=Prohlížeč a analyzátor GPS logů
+Comment[cs]=Prohlížeč a analyzátor GPS logů
 Comment[fi]=Ohjelma GPS-lokien katseluun ja analysointiin
 Comment[fr]=Visualisation et analyse de fichier GPS
 Comment[nb]=GPS-loggfilleser og analysator


### PR DESCRIPTION
"cz" is not a valid locale name, "cs" is.

(Same as the Czech po files name.)